### PR TITLE
Fix release workflow for branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,16 +118,45 @@ jobs:
         
         echo "changelog-file=CHANGELOG_TEMP.md" >> $GITHUB_OUTPUT
 
-    - name: Commit version bump
+    - name: Create version bump branch
       run: |
+        BRANCH_NAME="release/v${{ steps.bump.outputs.new-version }}"
+        git checkout -b "$BRANCH_NAME"
         git add package.json package-lock.json
         git commit -m "chore: bump version to v${{ steps.bump.outputs.new-version }} [skip ci]"
-        git tag "v${{ steps.bump.outputs.new-version }}"
+        git push origin "$BRANCH_NAME"
+        echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+      id: branch
 
-    - name: Push changes
+    - name: Create version bump PR
       run: |
-        git push origin main
+        PR_URL=$(gh pr create \
+          --title "chore: bump version to v${{ steps.bump.outputs.new-version }}" \
+          --body "Automated version bump to v${{ steps.bump.outputs.new-version }}" \
+          --base main \
+          --head "${{ steps.branch.outputs.branch-name }}")
+        echo "pr-url=$PR_URL" >> $GITHUB_OUTPUT
+      id: pr
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Auto-merge version bump PR
+      run: |
+        # Enable auto-merge and merge the PR
+        gh pr merge "${{ steps.pr.outputs.pr-url }}" --auto --squash
+        
+        # Wait for merge to complete
+        sleep 10
+        
+        # Switch back to main and pull the merged changes
+        git checkout main
+        git pull origin main
+        
+        # Create and push the tag
+        git tag "v${{ steps.bump.outputs.new-version }}"
         git push origin "v${{ steps.bump.outputs.new-version }}"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create GitHub Release
       uses: actions/create-release@v1


### PR DESCRIPTION
## Summary
Update release workflow to work with branch protection rules that require pull requests

## Problem
The release workflow was failing because it tried to push directly to main branch, which violates the "Changes must be made through a pull request" rule.

## Solution
- Create version bump in a separate branch
- Create pull request for version bump
- Auto-merge the PR
- Create git tag after successful merge

## Changes
- Modified `.github/workflows/release.yml` to use PR-based version bumps
- Workflow now creates `release/v{version}` branch for version bumps
- Uses `gh pr create` and `gh pr merge --auto` for automated merging

## Test plan
- [ ] Test workflow runs without branch protection violations
- [ ] Verify version bump PR is created and merged automatically
- [ ] Confirm git tag is created after merge
- [ ] Validate npm publish still works after these changes