### PR TITLE
Potential fix for code scanning alert no. 1: Expression injection in Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,10 @@ jobs:
 
     - name: Determine version bump
       id: version
+      env:
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
       run: |
         # Check commit messages for version bump indicators
-        COMMIT_MSG="${{ github.event.head_commit.message }}"
-        
         if [[ "$COMMIT_MSG" == *"BREAKING CHANGE"* ]] || [[ "$COMMIT_MSG" == *"[major]"* ]]; then
           echo "bump=major" >> $GITHUB_OUTPUT
         elif [[ "$COMMIT_MSG" == *"feat"* ]] || [[ "$COMMIT_MSG" == *"[minor]"* ]]; then


### PR DESCRIPTION
Potential fix for [https://github.com/ThaSiouL/bc-symbols-mcp/security/code-scanning/1](https://github.com/ThaSiouL/bc-symbols-mcp/security/code-scanning/1)

To fix the issue, the untrusted input (`github.event.head_commit.message`) should be assigned to an intermediate environment variable and then used with native shell syntax to prevent injection. This approach ensures that the input is treated as a literal string rather than being evaluated as part of the shell script.

The changes will involve:
1. Assigning `github.event.head_commit.message` to an environment variable.
2. Using the environment variable in the shell script with native shell syntax (`$VAR`) instead of `${{ env.VAR }}`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
