### PR TITLE
Add manual trigger for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'
       - '.github/**'
       - '**/*.md'
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
Add `workflow_dispatch` trigger to the release workflow for manual execution

## Problem
Recent PRs that only modified `.github/workflows/release.yml` didn't trigger the release workflow because `.github/**` is in the `paths-ignore` list.

## Solution
- Add `workflow_dispatch` trigger to allow manual releases
- Keeps existing automation for code changes
- Provides flexibility for testing or emergency releases

## Usage
After merging, you can manually trigger releases from:
- GitHub Actions tab → Release workflow → Run workflow button
- GitHub CLI: `gh workflow run release.yml`

## Benefits
- ✅ Test releases without code changes
- ✅ Trigger releases when workflow changes don't auto-trigger  
- ✅ Emergency releases when needed
- ✅ Maintains existing automation