### PR TITLE
fix: prevent release workflow loop and correct PR merge detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
       - 'docs/**'
       - '.github/**'
       - '**/*.md'
+      - 'package.json'
+      - 'package-lock.json'
   workflow_dispatch:
 
 jobs:
@@ -149,7 +151,7 @@ jobs:
         # Poll for merge completion instead of fixed sleep
         echo "Waiting for PR to be merged..."
         for i in {1..30}; do
-          if gh pr view "${{ steps.pr.outputs.pr-url }}" --json merged --jq '.merged' | grep -q true; then
+          if gh pr view "${{ steps.pr.outputs.pr-url }}" --json state --jq '.state' | grep -q "MERGED"; then
             echo "PR successfully merged!"
             break
           fi
@@ -158,7 +160,7 @@ jobs:
         done
         
         # Verify the PR was actually merged
-        if ! gh pr view "${{ steps.pr.outputs.pr-url }}" --json merged --jq '.merged' | grep -q true; then
+        if ! gh pr view "${{ steps.pr.outputs.pr-url }}" --json state --jq '.state' | grep -q "MERGED"; then
           echo "Error: PR was not merged after 5 minutes"
           exit 1
         fi


### PR DESCRIPTION
- Add package.json and package-lock.json to paths-ignore to prevent workflow triggering on version bumps
- Fix PR merge detection to use correct 'state' field instead of non-existent 'merged' field
- Resolves infinite loop caused by auto-merged version bump PRs

# Pull Request

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test updates
- [ ] ♻️ Code refactoring

## Changes Made
- 
- 
- 

## Testing
- [ ] Unit tests pass (`npm test`)
- [ ] Build succeeds (`npm run build`)
- [ ] Linting passes (`npm run lint`)
- [ ] Manual testing completed (if applicable)

## Version Impact
- [ ] **[patch]** - Bug fixes, small improvements
- [ ] **[minor]** - New features, non-breaking changes  
- [ ] **[major]** - Breaking changes (add `BREAKING CHANGE` to commit message)

## Checklist
- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (unless marked above)

## Additional Notes
Any additional information, context, or notes for reviewers.