### PR TITLE
fix: restore PR-based release workflow for protected main branch

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,141 @@
+name: Post-Merge Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release-on-merge:
+    # Only run if PR was merged (not just closed) and was a version bump PR
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.title, 'chore: bump version to v')
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write
+      packages: write
+      id-token: write # for npm provenance
+
+    steps:
+    - name: Checkout merged code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: main  # Ensure we're on the merged main branch
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24'
+        cache: 'npm'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build project
+      run: npm run build
+
+    - name: Extract version from package.json
+      id: version
+      run: |
+        VERSION=$(node -p "require('./package.json').version")
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Extracted version: $VERSION"
+
+    - name: Generate changelog
+      id: changelog
+      run: |
+        # Get the previous version tag
+        PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
+        
+        if [ -z "$PREV_TAG" ]; then
+          COMMITS=$(git log --oneline --pretty=format:"- %s (%h)" -n 20)
+        else
+          COMMITS=$(git log ${PREV_TAG}..HEAD --oneline --pretty=format:"- %s (%h)")
+        fi
+        
+        # Create changelog content
+        cat > CHANGELOG_TEMP.md << EOF
+        ## Changes in v${{ steps.version.outputs.version }}
+        
+        $COMMITS
+        
+        **Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...v${{ steps.version.outputs.version }}
+        EOF
+        
+        echo "changelog-file=CHANGELOG_TEMP.md" >> $GITHUB_OUTPUT
+
+    - name: Create and push tag
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        
+        # Create and push the tag
+        git tag "v${{ steps.version.outputs.version }}"
+        git push origin "v${{ steps.version.outputs.version }}"
+        echo "✅ Created and pushed tag v${{ steps.version.outputs.version }}"
+
+    - name: Create GitHub Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ steps.version.outputs.version }}
+        release_name: Release v${{ steps.version.outputs.version }}
+        body_path: ${{ steps.changelog.outputs.changelog-file }}
+        draft: false
+        prerelease: false
+
+    - name: Publish to NPM
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        # Publish with provenance for supply chain security
+        npm publish --access public --provenance
+        echo "✅ Published to NPM successfully with provenance"
+
+    - name: Create MCP Installation Instructions
+      run: |
+        cat > INSTALL_INSTRUCTIONS.md << EOF
+        # BC Symbols MCP v${{ steps.version.outputs.version }} Installation
+        
+        ## NPM Installation
+        \`\`\`bash
+        npm install -g bc-symbols-mcp@${{ steps.version.outputs.version }}
+        \`\`\`
+        
+        ## Direct MCP Installation
+        \`\`\`bash
+        npx @modelcontextprotocol/cli install bc-symbols-mcp
+        \`\`\`
+        
+        ## Usage
+        Add to your MCP client configuration:
+        \`\`\`json
+        {
+          "mcpServers": {
+            "bc-symbols": {
+              "command": "bc-symbols-mcp",
+              "args": []
+            }
+          }
+        }
+        \`\`\`
+        EOF
+
+    - name: Upload installation instructions
+      uses: actions/upload-artifact@v4
+      with:
+        name: installation-instructions-v${{ steps.version.outputs.version }}
+        path: INSTALL_INSTRUCTIONS.md
+        retention-days: 30
+
+    - name: Notify success
+      run: |
+        echo "🎉 Successfully released v${{ steps.version.outputs.version }}!"
+        echo "✅ GitHub release created"
+        echo "✅ NPM package published with provenance"
+        echo "✅ Installation instructions uploaded"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,8 @@ jobs:
     permissions:
       contents: write
       packages: write
-      id-token: write # for npm provenance
+      issues: write
+      pull-requests: write
 
     steps:
     - name: Checkout code
@@ -118,72 +119,35 @@ jobs:
         
         echo "changelog-file=CHANGELOG_TEMP.md" >> $GITHUB_OUTPUT
 
-    - name: Commit and push version bump
+    - name: Create version bump branch
       run: |
+        BRANCH_NAME="release/v${{ steps.bump.outputs.new-version }}"
+        git checkout -b "$BRANCH_NAME"
         git add package.json package-lock.json src/server.ts
         git commit -m "chore: bump version to v${{ steps.bump.outputs.new-version }} [skip ci]"
-        git push origin main
+        git push origin "$BRANCH_NAME"
+        echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+      id: branch
 
-    - name: Create and push tag
+    - name: Create version bump PR
       run: |
-        git tag "v${{ steps.bump.outputs.new-version }}"
-        git push origin "v${{ steps.bump.outputs.new-version }}"
-        echo "✅ Created and pushed tag v${{ steps.bump.outputs.new-version }}"
-
-    - name: Create GitHub Release
-      uses: actions/create-release@v1
+        PR_URL=$(gh pr create \
+          --title "chore: bump version to v${{ steps.bump.outputs.new-version }}" \
+          --body "Automated version bump to v${{ steps.bump.outputs.new-version }}" \
+          --base main \
+          --head "${{ steps.branch.outputs.branch-name }}")
+        echo "pr-url=$PR_URL" >> $GITHUB_OUTPUT
+      id: pr
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: v${{ steps.bump.outputs.new-version }}
-        release_name: Release v${{ steps.bump.outputs.new-version }}
-        body_path: ${{ steps.changelog.outputs.changelog-file }}
-        draft: false
-        prerelease: false
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Publish to NPM
+    - name: Enable auto-merge for version bump PR
+      run: |
+        gh pr merge "${{ steps.pr.outputs.pr-url }}" --auto --squash
+        echo "✅ Auto-merge enabled for PR: ${{ steps.pr.outputs.pr-url }}"
+        echo "🔄 Post-merge workflow will handle tagging and release creation"
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      run: |
-        # Publish with provenance for supply chain security
-        npm publish --access public --provenance
-        echo "✅ Published to NPM successfully with provenance"
-
-    - name: Create MCP Installation Instructions
-      run: |
-        cat > INSTALL_INSTRUCTIONS.md << EOF
-        # BC Symbols MCP v${{ steps.bump.outputs.new-version }} Installation
-        
-        ## NPM Installation
-        \`\`\`bash
-        npm install -g bc-symbols-mcp@${{ steps.bump.outputs.new-version }}
-        \`\`\`
-        
-        ## Direct MCP Installation
-        \`\`\`bash
-        npx @modelcontextprotocol/cli install bc-symbols-mcp
-        \`\`\`
-        
-        ## Usage
-        Add to your MCP client configuration:
-        \`\`\`json
-        {
-          "mcpServers": {
-            "bc-symbols": {
-              "command": "bc-symbols-mcp",
-              "args": []
-            }
-          }
-        }
-        \`\`\`
-        EOF
-
-    - name: Upload installation instructions
-      uses: actions/upload-artifact@v4
-      with:
-        name: installation-instructions-v${{ steps.bump.outputs.new-version }}
-        path: INSTALL_INSTRUCTIONS.md
-        retention-days: 30
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
   notify:
@@ -195,17 +159,16 @@ jobs:
     - name: Notify on success
       if: ${{ needs.release.result == 'success' }}
       run: |
-        echo "🎉 Release created successfully!"
+        echo "🎉 Version bump PR created successfully!"
         echo "✅ Tests passed"
-        echo "✅ Version bumped and committed"
-        echo "✅ GitHub release created"
-        echo "✅ NPM package published with provenance"
-        echo "✅ Installation instructions uploaded"
+        echo "✅ Version bump branch created"
+        echo "✅ Auto-merge enabled"
+        echo "🔄 Post-merge workflow will handle release after PR merges"
 
     - name: Notify on failure
       if: ${{ needs.test.result == 'failure' || needs.release.result == 'failure' }}
       run: |
-        echo "❌ Release failed!"
+        echo "❌ Version bump PR creation failed!"
         echo "Test result: ${{ needs.test.result }}"
         echo "Release result: ${{ needs.release.result }}"
         exit 1


### PR DESCRIPTION
## Problem
The streamlined workflow was trying to push directly to the protected main branch, which is not allowed:
```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## Solution
Restore the two-phase workflow approach that respects branch protection:

### Phase 1: Release Workflow (on push to main)
- Create version bump branch
- Create PR with version changes
- Enable auto-merge for the PR

### Phase 2: Post-Merge Workflow (on PR merge)
- Triggers when version bump PR is merged
- Creates tag and GitHub release
- Publishes to NPM with provenance
- Uploads installation instructions

## Benefits
- ✅ Respects protected main branch rules
- ✅ Maintains automated release process
- ✅ Keeps npm provenance for supply chain security
- ✅ Uses auto-merge for seamless automation
- ✅ Separates concerns: version bump vs release

## Test Plan
- [ ] Push to main should create version bump PR
- [ ] PR should auto-merge when checks pass
- [ ] Post-merge workflow should trigger and create release
- [ ] NPM package should be published with provenance